### PR TITLE
Bumping up version

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -1,2 +1,2 @@
-export externalsversion="1.1.10"
-export coreversion="1.1.10"
+export externalsversion="1.1.11"
+export coreversion="1.1.11"


### PR DESCRIPTION
New release due to changes in riaps-pycom.  No riaps-core changes from 1.1.10 to 1.1.11.