### PR TITLE
Change encrypt method for encrypt then auth

### DIFF
--- a/src/discoveryd/r_dhtdata.cc
+++ b/src/discoveryd/r_dhtdata.cc
@@ -10,14 +10,14 @@ namespace riaps {
         void DhtData::EncryptData(std::vector<uint8_t> &data,
                                   std::shared_ptr<dht::crypto::PrivateKey> private_key) {
             auto public_key = private_key->getPublicKey();
-            signature = private_key->sign(data);
             encrypted_data = public_key.encrypt(data);
+            signature = private_key->sign(encrypted_data);
         }
 
         bool DhtData::DecryptData(std::shared_ptr<dht::crypto::PrivateKey> private_key) {
             try {
-                auto data = private_key->decrypt(encrypted_data);
-                if (private_key->getPublicKey().checkSignature(data, signature)) {
+                if (private_key->getPublicKey().checkSignature(encrypted_data, signature)) {
+                    auto data = private_key->decrypt(encrypted_data);
                     raw_data = data;
                     return true;
                 }


### PR DESCRIPTION
encryption use rand values to avoid attacks like known-plaintext. Thus, sign encrypted data will generate different signatures for the same plaintext data. For this case, encrypting then auth is more appropriate.